### PR TITLE
Change the clobbers target to avoid conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-oauth",
-  "version": "2.1.0",
+  "version": "2.1.0-j5.1",
   "author": "Ayogo Health Inc. <info@ayogo.com>",
   "contributors": [
     "Darryl Pogue <darryl@dpogue.ca>",

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-oauth" version="2.1.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-oauth" version="2.1.0-j5.1">
   <name>cordova-plugin-oauth</name>
   <description>Cordova plugin for performing OAuth login flows.</description>
   <keywords>cordova,ios,android,oauth</keywords>

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,7 @@ limitations under the License.
   </engines>
 
   <js-module src="www/oauth.js" name="OAuth">
-    <clobbers target="open" />
+    <clobbers target="cordova.plugins.oauth.open" />
   </js-module>
 
   <config-file target="config.xml" parent="/*">


### PR DESCRIPTION
The `open` clobbers target didn't seem to play nicely with inappbrowser, so in the interests of avoiding issues with any other plugins, I've made the clobbers target to have a more useful namespace.